### PR TITLE
enable click completion in Autocomplete.Simple

### DIFF
--- a/src/Autocomplete/Simple.elm
+++ b/src/Autocomplete/Simple.elm
@@ -210,10 +210,11 @@ viewItem address model item index =
     [ model.config.itemHtmlFn item ]
 
 
-viewSelectedItem : Autocomplete -> Text -> Html
-viewSelectedItem model item =
+viewSelectedItem : Signal.Address Action -> Autocomplete -> Text -> Html
+viewSelectedItem address model item =
   li
     [ model.config.styleViewFn Styling.SelectedItem
+    , onClick address Complete
     ]
     [ model.config.itemHtmlFn item ]
 
@@ -231,7 +232,7 @@ viewList address model =
   let
     getItemView index item =
       if index == model.selectedItemIndex then
-        viewSelectedItem model item
+        viewSelectedItem address model item
       else
         viewItem address model item index
   in


### PR DESCRIPTION
Let me first say: Thank you for elm-autocomplete, you did a great job with it! :)

I was a little confused however, because just clicking on the selected item of the possible completion list, didn't work for any example with Autocomplete.Simple. I couldn't find a way to configure this behaviour. So, I had a look and found, that unlike the 'advanced' Autocomplete, the simple version doesn't allow it, which is why I created this PR to 'fix' this.

If this behaviour is intended, just dispose of this PR and never mind - but I couldn't find any indication of that.
