### PR TITLE
Hide Autocomplete Models Behind Tagged Union Type

### DIFF
--- a/src/Autocomplete.elm
+++ b/src/Autocomplete.elm
@@ -96,23 +96,17 @@ import Autocomplete.Styling as Styling
 {-| The Autocomplete model.
     It assumes filtering is based upon strings.
 -}
-type alias Autocomplete =
-  Model
-
-
-{-| The Autocomplete model.
-    It assumes filtering is based upon strings.
--}
-type alias Model =
-  { value : InputValue
-  , items : List Text
-  , matches : List Text
-  , selectedItemIndex : Index
-  , getItemsTask : GetItemsTask
-  , showMenu : Bool
-  , showLoading : Bool
-  , config : Config
-  }
+type Autocomplete
+  = Autocomplete
+      { value : InputValue
+      , items : List Text
+      , matches : List Text
+      , selectedItemIndex : Index
+      , getItemsTask : GetItemsTask
+      , showMenu : Bool
+      , showLoading : Bool
+      , config : Config
+      }
 
 
 {-| Consumer defined function that is used to retrieve more items. Called when either
@@ -126,15 +120,16 @@ type alias GetItemsTask =
 -}
 init : List String -> GetItemsTask -> ( Autocomplete, Effects Action )
 init items getItemsTask =
-  ( { value = ""
-    , items = items
-    , matches = items
-    , selectedItemIndex = 0
-    , getItemsTask = getItemsTask
-    , showMenu = False
-    , showLoading = False
-    , config = Config.defaultConfig
-    }
+  ( Autocomplete
+      { value = ""
+      , items = items
+      , matches = items
+      , selectedItemIndex = 0
+      , getItemsTask = getItemsTask
+      , showMenu = False
+      , showLoading = False
+      , config = Config.defaultConfig
+      }
   , Effects.none
   )
 
@@ -143,15 +138,16 @@ init items getItemsTask =
 -}
 initWithConfig : List String -> GetItemsTask -> Config -> ( Autocomplete, Effects Action )
 initWithConfig items getItemsTask config =
-  ( { value = ""
-    , items = items
-    , matches = items
-    , selectedItemIndex = 0
-    , getItemsTask = getItemsTask
-    , showMenu = False
-    , showLoading = False
-    , config = config
-    }
+  ( Autocomplete
+      { value = ""
+      , items = items
+      , matches = items
+      , selectedItemIndex = 0
+      , getItemsTask = getItemsTask
+      , showMenu = False
+      , showLoading = False
+      , config = config
+      }
   , Effects.none
   )
 
@@ -170,67 +166,68 @@ type Action
 {-| The quintessential Elm Architecture reducer.
 -}
 update : Action -> Autocomplete -> ( Autocomplete, Effects Action )
-update action model =
+update action (Autocomplete model) =
   case action of
     NoOp ->
-      ( model, Effects.none )
+      ( Autocomplete model, Effects.none )
 
     SetValue value ->
-      updateInputValue value model
+      updateInputValue value (Autocomplete model)
 
     UpdateItems items ->
-      ( { model
-          | items = items
-          , matches =
-              List.filter (\item -> model.config.filterFn item model.value) model.items
-                |> List.sortWith model.config.compareFn
-          , showLoading = False
-        }
+      ( Autocomplete
+          { model
+            | items = items
+            , matches =
+                List.filter (\item -> (getConfig model.config).filterFn item model.value) model.items
+                  |> List.sortWith (getConfig model.config).compareFn
+            , showLoading = False
+          }
       , Effects.none
       )
 
     Complete ->
-      case (getSelectedItem model) of
+      case getSelectedItem <| Autocomplete model of
         Just item ->
-          ( { model | value = item, showMenu = False }, Effects.none )
+          ( Autocomplete { model | value = item, showMenu = False }, Effects.none )
 
         Nothing ->
-          ( model, Effects.none )
+          ( Autocomplete model, Effects.none )
 
     ChangeSelection newIndex ->
       let
         boundedNewIndex =
           Basics.max newIndex 0
             |> Basics.min ((List.length model.matches) - 1)
-            |> Basics.min (model.config.maxListSize - 1)
+            |> Basics.min ((getConfig model.config).maxListSize - 1)
       in
-        ( { model | selectedItemIndex = boundedNewIndex }, Effects.none )
+        ( Autocomplete { model | selectedItemIndex = boundedNewIndex }, Effects.none )
 
     ShowMenu bool ->
-      ( { model | showMenu = bool }, Effects.none )
+      ( Autocomplete { model | showMenu = bool }, Effects.none )
 
 
 {-| The full Autocomplete view, with menu and input.
     Needs a Signal.Address and Autocomplete (typical of the Elm Architecture).
 -}
 view : Signal.Address Action -> Autocomplete -> Html
-view address model =
+view address (Autocomplete model) =
   div
     [ onBlur address (ShowMenu False) ]
-    [ viewInput address model
+    [ viewInput address (Autocomplete model)
     , if not model.showMenu then
         div [] []
       else if model.showLoading then
-        model.config.loadingDisplay
+        (getConfig model.config).loadingDisplay
       else if List.isEmpty model.matches then
-        model.config.noMatchesDisplay
+        (getConfig model.config).noMatchesDisplay
       else
-        viewMenu address model
+        viewMenu address (Autocomplete model)
     ]
 
 
 viewInput : Signal.Address Action -> Autocomplete -> Html
-viewInput address model =
+viewInput address (Autocomplete model) =
   let
     arrowUp =
       38
@@ -243,7 +240,7 @@ viewInput address model =
         ChangeSelection (model.selectedItemIndex - 1)
       else if code == arrowDown then
         ChangeSelection (model.selectedItemIndex + 1)
-      else if List.member code model.config.completionKeyCodes then
+      else if (List.member code (getConfig model.config).completionKeyCodes) then
         Complete
       else
         NoOp
@@ -254,52 +251,52 @@ viewInput address model =
       , on "keydown" keyCode (\code -> Signal.message address (handleKeyDown code))
       , onFocus address (ShowMenu True)
       , value model.value
-      , model.config.styleViewFn Styling.Input
+      , (getConfig model.config).styleViewFn Styling.Input
       , autocomplete True
       ]
       []
 
 
 viewItem : Signal.Address Action -> Autocomplete -> String -> Index -> Html
-viewItem address model item index =
+viewItem address (Autocomplete model) item index =
   li
-    [ model.config.styleViewFn Styling.Item
+    [ (getConfig model.config).styleViewFn Styling.Item
     , onMouseEnter address (ChangeSelection index)
     ]
-    [ model.config.itemHtmlFn item ]
+    [ (getConfig model.config).itemHtmlFn item ]
 
 
 viewSelectedItem : Signal.Address Action -> Autocomplete -> String -> Html
-viewSelectedItem address model item =
+viewSelectedItem address (Autocomplete model) item =
   li
-    [ model.config.styleViewFn Styling.SelectedItem
+    [ (getConfig model.config).styleViewFn Styling.SelectedItem
     , onClick address Complete
     ]
-    [ model.config.itemHtmlFn item ]
+    [ (getConfig model.config).itemHtmlFn item ]
 
 
 viewMenu : Signal.Address Action -> Autocomplete -> Html
-viewMenu address model =
+viewMenu address (Autocomplete model) =
   div
-    [ model.config.styleViewFn Styling.Menu
+    [ (getConfig model.config).styleViewFn Styling.Menu
     ]
-    [ viewList address model ]
+    [ viewList address (Autocomplete model) ]
 
 
 viewList : Signal.Address Action -> Autocomplete -> Html
-viewList address model =
+viewList address (Autocomplete model) =
   let
     getItemView index item =
       if index == model.selectedItemIndex then
-        viewSelectedItem address model item
+        viewSelectedItem address (Autocomplete model) item
       else
-        viewItem address model item index
+        viewItem address (Autocomplete model) item index
   in
     ul
-      [ model.config.styleViewFn Styling.List
+      [ (getConfig model.config).styleViewFn Styling.List
       ]
       (List.indexedMap getItemView model.matches
-        |> List.take model.config.maxListSize
+        |> List.take (getConfig model.config).maxListSize
       )
 
 
@@ -308,7 +305,7 @@ viewList address model =
 
 
 getMoreItems : String -> Autocomplete -> Effects Action
-getMoreItems value model =
+getMoreItems value (Autocomplete model) =
   model.getItemsTask value model.selectedItemIndex
     |> Task.map UpdateItems
     |> Effects.task
@@ -319,22 +316,23 @@ getMoreItems value model =
 
 
 updateInputValue : String -> Autocomplete -> ( Autocomplete, Effects Action )
-updateInputValue value model =
+updateInputValue value (Autocomplete model) =
   if value == "" then
-    ( { model
-        | value = value
-        , matches =
-            model.items
-              |> List.sortWith model.config.compareFn
-        , selectedItemIndex = 0
-      }
+    ( Autocomplete
+        { model
+          | value = value
+          , matches =
+              model.items
+                |> List.sortWith (getConfig model.config).compareFn
+          , selectedItemIndex = 0
+        }
     , Effects.none
     )
   else
     let
       matches =
-        List.filter (\item -> model.config.filterFn item value) model.items
-          |> List.sortWith model.config.compareFn
+        List.filter (\item -> (getConfig model.config).filterFn item value) model.items
+          |> List.sortWith (getConfig model.config).compareFn
 
       showLoading =
         if List.isEmpty matches then
@@ -342,18 +340,19 @@ updateInputValue value model =
         else
           False
     in
-      ( { model
-          | value = value
-          , matches = matches
-          , showLoading = showLoading
-          , selectedItemIndex = 0
-        }
-      , getMoreItems value model
+      ( Autocomplete
+          { model
+            | value = value
+            , matches = matches
+            , showLoading = showLoading
+            , selectedItemIndex = 0
+          }
+      , getMoreItems value (Autocomplete model)
       )
 
 
 getSelectedItem : Autocomplete -> Maybe String
-getSelectedItem model =
+getSelectedItem (Autocomplete model) =
   List.drop model.selectedItemIndex model.matches
     |> List.head
 
@@ -361,10 +360,14 @@ getSelectedItem model =
 {-| Get the text of the currently selected item
 -}
 getSelectedItemText : Autocomplete -> String
-getSelectedItemText model =
-  case (getSelectedItem model) of
+getSelectedItemText (Autocomplete model) =
+  case (getSelectedItem (Autocomplete model)) of
     Just item ->
       item
 
     Nothing ->
       model.value
+
+
+getConfig (Config.Config config) =
+  config

--- a/src/Autocomplete/Simple.elm
+++ b/src/Autocomplete/Simple.elm
@@ -51,45 +51,43 @@ import Autocomplete.Styling as Styling
 {-| The Autocomplete model.
     It assumes filtering is based upon strings.
 -}
-type alias Autocomplete =
-  Model
-
-
-{-| The Autocomplete model.
-    It assumes filtering is based upon strings.
--}
-type alias Model =
-  { value : InputValue
-  , items : List Text
-  , matches : List Text
-  , selectedItemIndex : Index
-  , showMenu : Bool
-  , config : Config
-  }
+type Autocomplete
+  = Autocomplete
+      { value : InputValue
+      , items : List Text
+      , matches : List Text
+      , selectedItemIndex : Index
+      , showMenu : Bool
+      , config : Config
+      }
 
 
 {-| Creates an Autocomplete from a list of items with a default `String.startsWith` filter
 -}
 init : List String -> Autocomplete
 init items =
-  { value = ""
-  , items = items
-  , matches = items
-  , selectedItemIndex = 0
-  , showMenu = False
-  , config = Config.defaultConfig
-  }
+  Autocomplete
+    { value = ""
+    , items = items
+    , matches = items
+    , selectedItemIndex = 0
+    , showMenu = False
+    , config = Config.defaultConfig
+    }
 
 
 {-| Creates an Autocomplete with a custom configuration
 -}
 initWithConfig : List String -> Config.Config -> Autocomplete
 initWithConfig items config =
-  let
-    model =
-      init items
-  in
-    { model | config = config }
+  Autocomplete
+    { value = ""
+    , items = items
+    , matches = items
+    , selectedItemIndex = 0
+    , showMenu = False
+    , config = config
+    }
 
 
 {-| A description of a state change
@@ -105,28 +103,30 @@ type Action
 {-| The quintessential Elm Architecture reducer.
 -}
 update : Action -> Autocomplete -> Autocomplete
-update action model =
+update action (Autocomplete model) =
   case action of
     NoOp ->
-      model
+      Autocomplete model
 
     SetValue value ->
       if value == "" then
-        { model
-          | value = value
-          , matches =
-              model.items
-                |> List.sortWith model.config.compareFn
-          , selectedItemIndex = 0
-        }
+        Autocomplete
+          { model
+            | value = value
+            , matches =
+                model.items
+                  |> List.sortWith model.config.compareFn
+            , selectedItemIndex = 0
+          }
       else
-        { model
-          | value = value
-          , matches =
-              List.filter (\item -> model.config.filterFn item value) model.items
-                |> List.sortWith model.config.compareFn
-          , selectedItemIndex = 0
-        }
+        Autocomplete
+          { model
+            | value = value
+            , matches =
+                List.filter (\item -> model.config.filterFn item value) model.items
+                  |> List.sortWith model.config.compareFn
+            , selectedItemIndex = 0
+          }
 
     Complete ->
       let
@@ -136,10 +136,10 @@ update action model =
       in
         case selectedItem of
           Just item ->
-            { model | value = item, showMenu = False }
+            Autocomplete { model | value = item, showMenu = False }
 
           Nothing ->
-            model
+            Autocomplete model
 
     ChangeSelection newIndex ->
       let
@@ -148,31 +148,31 @@ update action model =
             |> Basics.min ((List.length model.matches) - 1)
             |> Basics.min (model.config.maxListSize - 1)
       in
-        { model | selectedItemIndex = boundedNewIndex }
+        Autocomplete { model | selectedItemIndex = boundedNewIndex }
 
     ShowMenu bool ->
-      { model | showMenu = bool }
+      Autocomplete { model | showMenu = bool }
 
 
 {-| The full Autocomplete view, with menu and input.
     Needs a Signal.Address and Autocomplete (typical of the Elm Architecture).
 -}
 view : Address Action -> Autocomplete -> Html
-view address model =
+view address (Autocomplete model) =
   div
     [ onBlur address (ShowMenu False) ]
-    [ viewInput address model
+    [ viewInput address (Autocomplete model)
     , if not model.showMenu then
         div [] []
       else if List.isEmpty model.matches then
         model.config.noMatchesDisplay
       else
-        viewMenu address model
+        viewMenu address (Autocomplete model)
     ]
 
 
 viewInput : Address Action -> Autocomplete -> Html
-viewInput address model =
+viewInput address (Autocomplete model) =
   let
     arrowUp =
       38
@@ -202,7 +202,7 @@ viewInput address model =
 
 
 viewItem : Signal.Address Action -> Autocomplete -> Text -> Index -> Html
-viewItem address model item index =
+viewItem address (Autocomplete model) item index =
   li
     [ model.config.styleViewFn Styling.Item
     , onMouseEnter address (ChangeSelection index)
@@ -211,7 +211,7 @@ viewItem address model item index =
 
 
 viewSelectedItem : Signal.Address Action -> Autocomplete -> Text -> Html
-viewSelectedItem address model item =
+viewSelectedItem address (Autocomplete model) item =
   li
     [ model.config.styleViewFn Styling.SelectedItem
     , onClick address Complete
@@ -220,21 +220,21 @@ viewSelectedItem address model item =
 
 
 viewMenu : Signal.Address Action -> Autocomplete -> Html
-viewMenu address model =
+viewMenu address (Autocomplete model) =
   div
     [ model.config.styleViewFn Styling.Menu
     ]
-    [ viewList address model ]
+    [ viewList address (Autocomplete model) ]
 
 
 viewList : Signal.Address Action -> Autocomplete -> Html
-viewList address model =
+viewList address (Autocomplete model) =
   let
     getItemView index item =
       if index == model.selectedItemIndex then
-        viewSelectedItem address model item
+        viewSelectedItem address (Autocomplete model) item
       else
-        viewItem address model item index
+        viewItem address (Autocomplete model) item index
   in
     ul
       [ model.config.styleViewFn Styling.List
@@ -247,7 +247,7 @@ viewList address model =
 
 
 getSelectedItem : Autocomplete -> Maybe String
-getSelectedItem model =
+getSelectedItem (Autocomplete model) =
   List.drop model.selectedItemIndex model.matches
     |> List.head
 
@@ -255,8 +255,8 @@ getSelectedItem model =
 {-| Get the text of the currently selected item
 -}
 getSelectedItemText : Autocomplete -> Text
-getSelectedItemText model =
-  case (getSelectedItem model) of
+getSelectedItemText (Autocomplete model) =
+  case (getSelectedItem (Autocomplete model)) of
     Just item ->
       item
 


### PR DESCRIPTION
#### Motivation

The compiler will still show the underlying record's fields if `Autocomplete` is merely an alias.

By keeping this model hidden behind a tagged union type, the API will not leak its model's implementation details. This enforces API consumers to only build given the provided top level functions.
