### PR TITLE
Limit User to Providing a List of Class Names

### DIFF
--- a/example/autocomplete.css
+++ b/example/autocomplete.css
@@ -1,4 +1,4 @@
-.autocomplete-menu-default {
+.autocomplete-menu {
     position:absolute;
     left: 5px;
     margin-top: 5px;
@@ -11,16 +11,15 @@
     z-index: 11110 !important;
 }
 
-.autocomplete-selected-item-default {
-    background: #3366FF;
-    color: white;
+.autocomplete-selected-item {
+    color: #3366FF;
     display: block;
     padding: 5px 10px;
     border-bottom: 1px solid #DDD;
     cursor: pointer;
 }
 
-.autocomplete-list-default {
+.autocomplete-list {
     list-style:none;
     padding:0;
     margin:auto;
@@ -28,14 +27,14 @@
     overflow-y: auto;
 }
 
-.autocomplete-item-default {
+.autocomplete-item {
     display: block;
     padding: 5px 10px;
     border-bottom: 1px solid #DDD;
     cursor: pointer;
 }
 
-.autocomplete-input-default {
+.autocomplete-input {
     min-width: 120px;
     color: black;
     position: relative;

--- a/example/src/AdvancedExample.elm
+++ b/example/src/AdvancedExample.elm
@@ -9,23 +9,23 @@ import Html.Attributes exposing (style, class)
 import String
 
 
-styleView : Styling.View -> Html.Attribute
-styleView view =
+getClasses : Styling.View -> Styling.Classes
+getClasses view =
   case view of
     Styling.Menu ->
-      class "autocomplete-menu-default"
+      [ ( "autocomplete-menu", True ) ]
 
     Styling.List ->
-      class "autocomplete-list-default"
+      [ ( "autocomplete-list", True ) ]
 
     Styling.Item ->
-      class "autocomplete-item-default"
+      [ ( "autocomplete-item", True ) ]
 
     Styling.SelectedItem ->
-      class "autocomplete-selected-item-default"
+      [ ( "autocomplete-selected-item", True ) ]
 
     Styling.Input ->
-      class "autocomplete-input-default"
+      [ ( "autocomplete-input", True ) ]
 
 
 type alias Model =
@@ -39,7 +39,7 @@ init =
   let
     config =
       Autocomplete.Config.defaultConfig
-        |> Autocomplete.Config.setStyleViewFn styleView
+        |> Autocomplete.Config.setGetClasses getClasses
         |> Autocomplete.Config.setItemHtml getItemHtml
   in
     { autocompleteRemaining = ""

--- a/example/src/StyledExample.elm
+++ b/example/src/StyledExample.elm
@@ -5,7 +5,6 @@ import Autocomplete.Simple as Autocomplete exposing (initWithConfig, update, vie
 import Autocomplete.Styling as Styling
 import StartApp.Simple
 import Html
-import Html.Attributes exposing (class)
 
 
 testData : List String
@@ -18,23 +17,23 @@ testData =
   ]
 
 
-styleView : Styling.View -> Html.Attribute
-styleView view =
+getClasses : Styling.View -> Styling.Classes
+getClasses view =
   case view of
     Styling.Menu ->
-      class "autocomplete-menu-default"
+      [ ( "autocomplete-menu", True ) ]
 
     Styling.List ->
-      class "autocomplete-list-default"
+      [ ( "autocomplete-list", True ) ]
 
     Styling.Item ->
-      class "autocomplete-item-default"
+      [ ( "autocomplete-item", True ) ]
 
     Styling.SelectedItem ->
-      class "autocomplete-selected-item-default"
+      [ ( "autocomplete-selected-item", True ) ]
 
     Styling.Input ->
-      class "autocomplete-input-default"
+      [ ( "autocomplete-input", True ) ]
 
 
 main : Signal Html.Html
@@ -42,7 +41,7 @@ main =
   let
     config =
       Autocomplete.Config.defaultConfig
-        |> Autocomplete.Config.setStyleViewFn styleView
+        |> Autocomplete.Config.setGetClasses getClasses
   in
     StartApp.Simple.start
       { model = initWithConfig testData config

--- a/src/Autocomplete.elm
+++ b/src/Autocomplete.elm
@@ -84,6 +84,7 @@ The above example can be found in `example/src/RemoteExample.elm`.
 -}
 
 import Autocomplete.Config as Config exposing (Config, Index, Text, InputValue)
+import Autocomplete.DefaultStyles as DefaultStyles
 import Autocomplete.Model exposing (Model)
 import Autocomplete.Update as Autocomplete
 import Autocomplete.View exposing (viewMenu)
@@ -201,9 +202,9 @@ viewInput address (Autocomplete model) =
 
     handleKeyDown code =
       if code == arrowUp then
-        UpdateAutocomplete (Autocomplete.ChangeSelection (model.autocomplete.selectedItemIndex - 1))
+        UpdateAutocomplete <| Autocomplete.ChangeSelection (model.autocomplete.selectedItemIndex - 1)
       else if code == arrowDown then
-        UpdateAutocomplete (Autocomplete.ChangeSelection (model.autocomplete.selectedItemIndex + 1))
+        UpdateAutocomplete <| Autocomplete.ChangeSelection (model.autocomplete.selectedItemIndex + 1)
       else if (List.member code model.autocomplete.config.completionKeyCodes) then
         UpdateAutocomplete Autocomplete.Complete
       else
@@ -215,8 +216,10 @@ viewInput address (Autocomplete model) =
       , on "keydown" keyCode (\code -> Signal.message address (handleKeyDown code))
       , onFocus address (UpdateAutocomplete (Autocomplete.ShowMenu True))
       , value model.autocomplete.value
-      , model.autocomplete.config.styleViewFn Styling.Input
-      , autocomplete True
+      , if model.autocomplete.config.useDefaultStyles then
+          DefaultStyles.inputStyle
+        else
+          classList <| model.autocomplete.config.getClasses Styling.Input
       ]
       []
 

--- a/src/Autocomplete/Config.elm
+++ b/src/Autocomplete/Config.elm
@@ -1,4 +1,4 @@
-module Autocomplete.Config (Config, ItemHtmlFn, Text, InputValue, Index, defaultConfig, setStyleViewFn, setCompletionKeyCodes, setItemHtml, setMaxListSize, setFilterFn, setCompareFn, setNoMatchesDisplay, setLoadingDisplay) where
+module Autocomplete.Config (Config, ItemHtmlFn, Text, InputValue, Index, defaultConfig, setGetClasses, setCompletionKeyCodes, setItemHtml, setMaxListSize, setFilterFn, setCompareFn, setNoMatchesDisplay, setLoadingDisplay) where
 
 {-| Configuration module for the Autocomplete component.
 
@@ -9,7 +9,7 @@ module Autocomplete.Config (Config, ItemHtmlFn, Text, InputValue, Index, default
 @docs defaultConfig
 
 # Modifiers
-@docs setStyleViewFn, setCompletionKeyCodes, setItemHtml, setMaxListSize, setFilterFn, setCompareFn, setNoMatchesDisplay, setLoadingDisplay
+@docs setGetClasses, setCompletionKeyCodes, setItemHtml, setMaxListSize, setFilterFn, setCompareFn, setNoMatchesDisplay, setLoadingDisplay
 
 
 -}
@@ -27,7 +27,8 @@ type alias Config =
 
 
 type alias Model =
-  { styleViewFn : Styling.View -> Attribute
+  { getClasses : Styling.View -> Styling.Classes
+  , useDefaultStyles : Bool
   , completionKeyCodes : List KeyCode
   , itemHtmlFn : ItemHtmlFn
   , maxListSize : Int
@@ -62,11 +63,11 @@ type alias Index =
   Int
 
 
-{-| Provide a function that produces an attribute to style a particular View
+{-| Provide a function that produces an list of classes to style a particular View
 -}
-setStyleViewFn : (Styling.View -> Attribute) -> Config -> Config
-setStyleViewFn styleViewFn config =
-  { config | styleViewFn = styleViewFn }
+setGetClasses : (Styling.View -> Styling.Classes) -> Config -> Config
+setGetClasses getClasses config =
+  { config | getClasses = getClasses, useDefaultStyles = False }
 
 
 {-| Provide keycodes for autocompletion. By default, completion happens on tab press.
@@ -126,7 +127,8 @@ setLoadingDisplay loadingDisplay config =
 -}
 defaultConfig : Config
 defaultConfig =
-  { styleViewFn = Styling.defaultStyles
+  { getClasses = (\view -> [])
+  , useDefaultStyles = True
   , completionKeyCodes =
       [ 9 ]
       -- defaults to tab

--- a/src/Autocomplete/DefaultStyles.elm
+++ b/src/Autocomplete/DefaultStyles.elm
@@ -1,0 +1,65 @@
+module Autocomplete.DefaultStyles (..) where
+
+import Html exposing (Attribute)
+import Html.Attributes exposing (style)
+
+
+menuStyle : Attribute
+menuStyle =
+  style
+    [ ( "position", "absolute" )
+    , ( "left", "5px" )
+    , ( "margin-top", "5px" )
+    , ( "background", "white" )
+    , ( "color", "black" )
+    , ( "border", "1px solid #DDD" )
+    , ( "border-radius", "3px" )
+    , ( "box-shadow", "0 0 5px rgba(0,0,0,0.1)" )
+    , ( "min-width", "120px" )
+    , ( "z-index", "11110" )
+    ]
+
+
+selectedItemStyle : Attribute
+selectedItemStyle =
+  style
+    [ ( "background", "#3366FF" )
+    , ( "color", "white" )
+    , ( "display", "block" )
+    , ( "padding", "5px 10px" )
+    , ( "border-bottom", "1px solid #DDD" )
+    , ( "cursor", "pointer" )
+    ]
+
+
+listStyle : Attribute
+listStyle =
+  style
+    [ ( "list-style", "none" )
+    , ( "padding", "0" )
+    , ( "margin", "auto" )
+    , ( "max-height", "200px" )
+    , ( "overflow-y", "auto" )
+    ]
+
+
+itemStyle : Attribute
+itemStyle =
+  style
+    [ ( "display", "block" )
+    , ( "padding", "5px 10px" )
+    , ( "border-bottom", "1px solid #DDD" )
+    , ( "cursor", "pointer" )
+    ]
+
+
+inputStyle : Attribute
+inputStyle =
+  style
+    [ ( "min-width", "120px" )
+    , ( "color", "black" )
+    , ( "position", "relative" )
+    , ( "display", "block" )
+    , ( "padding", "0.8em" )
+    , ( "font-size", "12px" )
+    ]

--- a/src/Autocomplete/Simple.elm
+++ b/src/Autocomplete/Simple.elm
@@ -41,14 +41,15 @@ main =
 -}
 
 import Autocomplete.Config as Config exposing (Config, Text, Index, InputValue)
-import Html exposing (..)
-import Html.Attributes exposing (..)
-import Html.Events exposing (..)
-import Signal exposing (..)
+import Autocomplete.DefaultStyles as DefaultStyles
 import Autocomplete.Styling as Styling
 import Autocomplete.Model exposing (Model)
 import Autocomplete.View exposing (viewMenu)
 import Autocomplete.Update as Autocomplete
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (..)
+import Signal exposing (..)
 
 
 {-| The Autocomplete model.
@@ -121,9 +122,9 @@ viewInput address model =
 
     handleKeyDown code =
       if code == arrowUp then
-        UpdateAutocomplete (Autocomplete.ChangeSelection (model.selectedItemIndex - 1))
+        UpdateAutocomplete <| Autocomplete.ChangeSelection (model.selectedItemIndex - 1)
       else if code == arrowDown then
-        UpdateAutocomplete (Autocomplete.ChangeSelection (model.selectedItemIndex + 1))
+        UpdateAutocomplete <| Autocomplete.ChangeSelection (model.selectedItemIndex + 1)
       else if List.member code model.config.completionKeyCodes then
         UpdateAutocomplete Autocomplete.Complete
       else
@@ -135,7 +136,10 @@ viewInput address model =
       , on "keydown" keyCode (\code -> Signal.message address (handleKeyDown code))
       , onFocus address (UpdateAutocomplete (Autocomplete.ShowMenu True))
       , value model.value
-      , model.config.styleViewFn Styling.Input
+      , if model.config.useDefaultStyles then
+          DefaultStyles.inputStyle
+        else
+          classList <| model.config.getClasses Styling.Input
       ]
       []
 

--- a/src/Autocomplete/Styling.elm
+++ b/src/Autocomplete/Styling.elm
@@ -1,4 +1,4 @@
-module Autocomplete.Styling (View(Menu, List, Item, SelectedItem, Input), defaultStyles) where
+module Autocomplete.Styling (View(Menu, List, Item, SelectedItem, Input), Classes) where
 
 {-| Styling module for the Autocomplete component.
 
@@ -17,29 +17,31 @@ testData =
   , "easy"
   ]
 
-styleView : Styling.View -> Html.Attribute
-styleView view =
+getClasses : Styling.View -> Styling.Classes
+getClasses view =
   case view of
     Styling.Menu ->
-      class "autocomplete-menu-default"
+      [ ( "autocomplete-menu", True ) ]
 
     Styling.List ->
-      class "autocomplete-list-default"
+      [ ( "autocomplete-list", True ) ]
 
     Styling.Item ->
-      class "autocomplete-item-default"
+      [ ( "autocomplete-item", True ) ]
 
     Styling.SelectedItem ->
-      class "autocomplete-selected-item-default"
+      [ ( "autocomplete-selected-item", True ) ]
 
     Styling.Input ->
-      class "autocomplete-input-default"
+      [ ( "autocomplete-input", True ) ]
 
+
+main : Signal Html.Html
 main =
   let
     config =
       Autocomplete.Config.defaultConfig
-        |> Autocomplete.Config.setStyleViewFn styleView
+        |> Autocomplete.Config.setGetClasses getClasses
   in
     StartApp.Simple.start
       { model = initWithConfig testData config
@@ -51,13 +53,10 @@ main =
 # Child Views
 @docs View
 
-# Defaults
-@docs defaultStyles
+# Definition
+@docs Classes
 
 -}
-
-import Html exposing (Attribute)
-import Html.Attributes exposing (style)
 
 
 {-| A list of class names and their associated status (added/removed) as a boolean value.
@@ -74,89 +73,3 @@ type View
   | Item
   | SelectedItem
   | Input
-
-
-{-| Produces a style attribute for a View. Uses some pretty defaults.
--}
-defaultStyles : View -> Attribute
-defaultStyles view =
-  case view of
-    Menu ->
-      menuStyle
-
-    List ->
-      listStyle
-
-    Item ->
-      itemStyle
-
-    SelectedItem ->
-      selectedItemStyle
-
-    Input ->
-      inputStyle
-
-
-
--- DEFAULTS
-
-
-menuStyle : Attribute
-menuStyle =
-  style
-    [ ( "position", "absolute" )
-    , ( "left", "5px" )
-    , ( "margin-top", "5px" )
-    , ( "background", "white" )
-    , ( "color", "black" )
-    , ( "border", "1px solid #DDD" )
-    , ( "border-radius", "3px" )
-    , ( "box-shadow", "0 0 5px rgba(0,0,0,0.1)" )
-    , ( "min-width", "120px" )
-    , ( "z-index", "11110" )
-    ]
-
-
-selectedItemStyle : Attribute
-selectedItemStyle =
-  style
-    [ ( "background", "#3366FF" )
-    , ( "color", "white" )
-    , ( "display", "block" )
-    , ( "padding", "5px 10px" )
-    , ( "border-bottom", "1px solid #DDD" )
-    , ( "cursor", "pointer" )
-    ]
-
-
-listStyle : Attribute
-listStyle =
-  style
-    [ ( "list-style", "none" )
-    , ( "padding", "0" )
-    , ( "margin", "auto" )
-    , ( "max-height", "200px" )
-    , ( "overflow-y", "auto" )
-    ]
-
-
-itemStyle : Attribute
-itemStyle =
-  style
-    [ ( "display", "block" )
-    , ( "padding", "5px 10px" )
-    , ( "border-bottom", "1px solid #DDD" )
-    , ( "cursor", "pointer" )
-    ]
-
-
-inputStyle : Attribute
-inputStyle =
-  style
-    [ ( "min-width", "120px" )
-    , ( "color", "black" )
-    , ( "position", "relative" )
-    , ( "display", "block" )
-    , ( "padding", "0.8em" )
-    , ( "font-size", "12px" )
-    ]

--- a/src/Autocomplete/View.elm
+++ b/src/Autocomplete/View.elm
@@ -1,10 +1,12 @@
 module Autocomplete.View (viewMenu) where
 
+import Autocomplete.DefaultStyles as DefaultStyles
 import Autocomplete.Update as Autocomplete exposing (Action)
 import Autocomplete.Model exposing (Model)
 import Autocomplete.Config exposing (Text, Index, InputValue)
 import Autocomplete.Styling as Styling
 import Html exposing (..)
+import Html.Attributes exposing (classList)
 import Html.Events exposing (..)
 import Signal exposing (Address)
 
@@ -12,7 +14,10 @@ import Signal exposing (Address)
 viewItem : Address Action -> Model -> Text -> Index -> Html
 viewItem address model item index =
   li
-    [ model.config.styleViewFn Styling.Item
+    [ if model.config.useDefaultStyles then
+        DefaultStyles.itemStyle
+      else
+        classList <| model.config.getClasses Styling.Item
     , onMouseEnter address (Autocomplete.ChangeSelection index)
     ]
     [ model.config.itemHtmlFn item ]
@@ -21,7 +26,10 @@ viewItem address model item index =
 viewSelectedItem : Address Action -> Model -> Text -> Html
 viewSelectedItem address model item =
   li
-    [ model.config.styleViewFn Styling.SelectedItem
+    [ if model.config.useDefaultStyles then
+        DefaultStyles.selectedItemStyle
+      else
+        classList <| model.config.getClasses Styling.SelectedItem
     , onClick address Autocomplete.Complete
     ]
     [ model.config.itemHtmlFn item ]
@@ -30,7 +38,10 @@ viewSelectedItem address model item =
 viewMenu : Address Action -> Model -> Html
 viewMenu address model =
   div
-    [ model.config.styleViewFn Styling.Menu
+    [ if model.config.useDefaultStyles then
+        DefaultStyles.menuStyle
+      else
+        classList <| model.config.getClasses Styling.Menu
     ]
     [ viewList address model ]
 
@@ -45,6 +56,9 @@ viewList address model =
         viewItem address model item index
   in
     ul
-      [ model.config.styleViewFn Styling.List
+      [ if model.config.useDefaultStyles then
+          DefaultStyles.listStyle
+        else
+          classList <| model.config.getClasses Styling.List
       ]
       (List.indexedMap getItemView model.matches)


### PR DESCRIPTION
Before, a user could just provide any attribute. This could dangerously override any other Html attribute on an Autocomplete view. Limiting access here to a list of classnames means less flexibility to the autocomplete but lends more clarity and consistent functionality.
