### PR TITLE
update matches when using `setItems`

### DIFF
--- a/src/Autocomplete.elm
+++ b/src/Autocomplete.elm
@@ -177,7 +177,7 @@ updateModel msg model =
       ( { model
           | items = items
           , matches =
-              List.filter (\item -> model.config.filterFn item model.value) model.items
+              List.filter (\item -> model.config.filterFn item model.value) items
                 |> List.sortWith model.config.compareFn
         }
       , defaultStatus


### PR DESCRIPTION
Currently using `setItems` will not result in an update of the potential matches, because filtering will be done using the - by then - old items contained in the current `model`.

I ran into that, while continually updating the items on user input with completions returned by a remote server. The completions were always 'one char behind'. :D

To make sure, this actually solves the problem, I went ahead and copied the updated code into my project and tried it - with success.

If you need anything else, or this was in fact intended, let me know. :) 

Besides that, nice API changes in 3.0!
