### PR TITLE
Provide option to hide menu if text input is empty

### DIFF
--- a/examples/src/TypeaheadExample.elm
+++ b/examples/src/TypeaheadExample.elm
@@ -42,6 +42,7 @@ init =
       Autocomplete.Config.defaultConfig
         |> Autocomplete.Config.setClassesFn getClasses
         |> Autocomplete.Config.setItemHtml getItemHtml
+        |> Autocomplete.Config.hideMenuIfEmpty True
   in
     { autocompleteRemaining = ""
     , autocomplete = Autocomplete.initWithConfig [ "elm", "makes", "coding", "life", "easy" ] config

--- a/src/Autocomplete.elm
+++ b/src/Autocomplete.elm
@@ -67,6 +67,7 @@ import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Json.Decode as Json
+import String
 
 
 {-| The Autocomplete model.
@@ -175,7 +176,11 @@ updateModel msg model =
         ( { model | selectedItemIndex = boundedNewIndex }, { defaultStatus | selectionChanged = True } )
 
     ShowMenu bool ->
-      ( { model | showMenu = bool }, defaultStatus )
+      let
+        shouldShowMenu =
+          if model.config.hideMenuIfEmpty && (String.isEmpty model.value) then False else bool
+      in
+        ( { model | showMenu = shouldShowMenu }, defaultStatus )
 
     UpdateItems items ->
       ( { model

--- a/src/Autocomplete/Config.elm
+++ b/src/Autocomplete/Config.elm
@@ -1,4 +1,4 @@
-module Autocomplete.Config exposing (Config, ItemHtmlFn, Text, InputValue, Index, Accessibility, Completed, ValueChanged, SelectionChanged, defaultConfig, isValueControlled, setClassesFn, setCompletionKeyCodes, setItemHtml, setMaxListSize, setFilterFn, setCompareFn, setNoMatchesDisplay, setLoadingDisplay, setAccessibilityProperties)
+module Autocomplete.Config exposing (Config, ItemHtmlFn, Text, InputValue, Index, Accessibility, Completed, ValueChanged, SelectionChanged, defaultConfig, hideMenuIfEmpty, isValueControlled, setClassesFn, setCompletionKeyCodes, setItemHtml, setMaxListSize, setFilterFn, setCompareFn, setNoMatchesDisplay, setLoadingDisplay, setAccessibilityProperties)
 
 {-| Configuration module for the Autocomplete component.
 
@@ -38,6 +38,7 @@ type alias Model msg =
   , loadingDisplay : Html msg
   , isValueControlled : Bool
   , accessibility : Maybe Accessibility
+  , hideMenuIfEmpty : Bool
   }
 
 {-| Information needed for better screen reader accessibility.
@@ -84,6 +85,14 @@ type alias ValueChanged =
 type alias SelectionChanged =
   Bool
 
+
+{-| Provide True to hide the autocomplete menu if the input field is empty.
+    False to show the autocomplete menu whenever the input field has focus.
+    The default config provides False.
+-}
+hideMenuIfEmpty : Bool -> Config msg -> Config msg
+hideMenuIfEmpty bool config =
+  { config | hideMenuIfEmpty = bool }
 
 {-| Provide True to control the autocomplete value,
     False to let the component control the value via a stylable `input` field.
@@ -175,6 +184,7 @@ defaultConfig =
   , loadingDisplay = p [] [ text "..." ]
   , isValueControlled = False
   , accessibility = Nothing
+  , hideMenuIfEmpty = False
   }
 
 


### PR DESCRIPTION
I found having the menu automatically appear as soon as the text input has focus a bit jarring from a UX perspective - most autocomplete/typeahead components I've come across usually wait until the user has entered at least one character. So I've provided this as a config option - `hideMenuIfEmpty` - which defaults to False but, if True, will hide the menu if the text input is empty.
