### PR TITLE
upgrade to 0.18.0 release

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -11,9 +11,9 @@
     ],
     "native-modules": true,
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/keyboard": "1.0.0 <= v < 2.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/examples/Demo.elm
+++ b/examples/Demo.elm
@@ -1,15 +1,15 @@
 module Main exposing (..)
 
 import Html exposing (..)
-import Html.App as Html
 import Html.Attributes exposing (..)
+import Tuple
 import AccessibleExample
 import SectionsExample
 import Svg exposing (path)
 import Svg.Attributes exposing (d, fill, viewBox)
 
 
-main : Program Never
+main : Program Never Model Msg
 main =
     Html.program
         { init = init ! []
@@ -73,7 +73,7 @@ update msg model =
                                 _ ->
                                     model
                     in
-                        { model | accessibleAutocomplete = fst <| AccessibleExample.update autoMsg model.accessibleAutocomplete }
+                        { model | accessibleAutocomplete = Tuple.first <| AccessibleExample.update autoMsg model.accessibleAutocomplete }
                             |> toggleFocus autoMsg
 
                 SectionsExample autoMsg ->
@@ -86,7 +86,7 @@ update msg model =
                                 _ ->
                                     model
                     in
-                        { model | sectionsAutocomplete = fst <| SectionsExample.update autoMsg model.sectionsAutocomplete }
+                        { model | sectionsAutocomplete = Tuple.first <| SectionsExample.update autoMsg model.sectionsAutocomplete }
                             |> toggleFocus autoMsg
     in
         ( newModel, Cmd.none )
@@ -213,11 +213,11 @@ viewFooter =
 
 
 footerLink : String -> String -> Html Msg
-footerLink url text' =
+footerLink url text_ =
     a
         [ href url
         , class "footer-link"
         , target "_blank"
         , rel "noopenner noreferrer"
         ]
-        [ text text' ]
+        [ text text_ ]

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -10,12 +10,12 @@
     "exposed-modules": [],
     "native-modules": true,
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/dom": "1.1.0 <= v < 2.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "elm-lang/http": "1.0.0 <= v < 2.0.0",
         "elm-lang/keyboard": "1.0.0 <= v < 2.0.0",
-        "elm-lang/svg": "1.1.1 <= v < 2.0.0",
-        "evancz/elm-http": "3.0.1 <= v < 4.0.0"
+        "elm-lang/svg": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/examples/src/MentionsExample.elm
+++ b/examples/src/MentionsExample.elm
@@ -4,12 +4,11 @@ import Autocomplete
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
-import Html.App as Html
 import String
 import Json.Decode as Json
 
 
-main : Program Never
+main : Program Never Model Msg
 main =
     Html.program
         { init = init ! []
@@ -151,14 +150,25 @@ view model =
             { preventDefault = True, stopPropagation = False }
 
         dec =
-            (Json.customDecoder keyCode
+            (Json.map
                 (\code ->
                     if code == 38 || code == 40 then
                         Ok NoOp
                     else
                         Err "not handling that key"
                 )
+                keyCode
             )
+                |> Json.andThen fromResult
+
+        fromResult : Result String a -> Json.Decoder a
+        fromResult result =
+            case result of
+                Ok val ->
+                    Json.succeed val
+
+                Err reason ->
+                    Json.fail reason
 
         menu =
             if model.showMenu then

--- a/examples/src/SectionsExample.elm
+++ b/examples/src/SectionsExample.elm
@@ -4,12 +4,11 @@ import Autocomplete
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
-import Html.App as Html
 import String
 import Json.Decode as Json
 
 
-main : Program Never
+main : Program Never Model Msg
 main =
     Html.program
         { init = init ! []
@@ -104,14 +103,26 @@ view model =
             { preventDefault = True, stopPropagation = False }
 
         dec =
-            (Json.customDecoder keyCode
+            (Json.map
                 (\code ->
                     if code == 38 || code == 40 then
                         Ok NoOp
                     else
                         Err "not handling that key"
                 )
+                keyCode
             )
+                |> Json.andThen
+                    fromResult
+
+        fromResult : Result String a -> Json.Decoder a
+        fromResult result =
+            case result of
+                Ok val ->
+                    Json.succeed val
+
+                Err reason ->
+                    Json.fail reason
     in
         div []
             [ input

--- a/src/Autocomplete.elm
+++ b/src/Autocomplete.elm
@@ -68,7 +68,6 @@ just tell the autocomplete how to grab an ID for a section and its related data.
 
 import Autocomplete.Autocomplete as Internal
 import Html exposing (..)
-import Html.App as Html
 import Char exposing (KeyCode)
 
 
@@ -307,8 +306,8 @@ viewWithSectionsConfig :
     }
     -> ViewWithSectionsConfig data sectionData
 viewWithSectionsConfig config =
-    ViewWithSectionsConfig
-        <| case config.section of
+    ViewWithSectionsConfig <|
+        case config.section of
             SectionConfig section ->
                 Internal.viewWithSectionsConfig { config | section = section }
 

--- a/src/Autocomplete/Autocomplete.elm
+++ b/src/Autocomplete/Autocomplete.elm
@@ -26,7 +26,6 @@ module Autocomplete.Autocomplete
 
 import Char exposing (KeyCode)
 import Html exposing (Html, Attribute)
-import Html.App
 import Html.Keyed
 import Html.Events
 import Keyboard
@@ -281,7 +280,7 @@ viewSection config state section =
             List.map trickyMap sectionNode.attributes
 
         customChildren =
-            List.map (Html.App.map (\html -> NoOp)) sectionNode.children
+            List.map (Html.map (\html -> NoOp)) sectionNode.children
 
         getKeyedItems datum =
             ( config.toId datum, viewData config state datum )
@@ -327,7 +326,7 @@ viewData { toId, li } { key, mouse } data =
                     False
     in
         Html.li customLiAttr
-            (List.map (Html.App.map (\html -> NoOp)) listItemData.children)
+            (List.map (Html.map (\html -> NoOp)) listItemData.children)
 
 
 viewList : ViewConfig data -> Int -> State -> List data -> Html Msg
@@ -373,7 +372,7 @@ viewItem { toId, li } { key, mouse } data =
                     False
     in
         Html.li customLiAttr
-            (List.map (Html.App.map (\html -> NoOp)) listItemData.children)
+            (List.map (Html.map (\html -> NoOp)) listItemData.children)
 
 
 type alias HtmlDetails msg =


### PR DESCRIPTION
I tried to update the module for the upcoming 0.18 release. 
It appears that `Json.customDecoder` was removed, and got stuck. Would you mind taking a look? 

I believe everything else works. 